### PR TITLE
Bug correction: Reference numbers too long sometimes

### DIFF
--- a/class.einzahlungsschein.php
+++ b/class.einzahlungsschein.php
@@ -458,7 +458,7 @@ class Einzahlungsschein {
 	private function createCompleteReferenceNumber() {
 	
 		//get reference number and fill with zeros
-		$completeReferenceNumber = str_pad($this->ezs_referenceNumber, 20 ,'0', STR_PAD_LEFT);
+		$completeReferenceNumber = str_pad($this->ezs_referenceNumber, (26 - strlen($this->ezs_bankingCustomerIdentification)) ,'0', STR_PAD_LEFT);
 	
 		//add customer identification code
 		$completeReferenceNumber = $this->ezs_bankingCustomerIdentification.$completeReferenceNumber;


### PR DESCRIPTION
The reference number has a maximum length of 27 characters (including
checksum). Depending on banking customer identification number, the
generated reference number could be too long. This has been corrected by
taking into account the length of said identification number.
